### PR TITLE
WIP: Gcn broker + localization crossmatch

### DIFF
--- a/conf/supervisord_ingester.conf.template
+++ b/conf/supervisord_ingester.conf.template
@@ -58,6 +58,16 @@ stdout_logfile_maxbytes = 50MB
 redirect_stderr = True
 environment = PYTHONPATH=".", PRODUCTION=1
 
+[program:dask-cluster-gcn]
+command = python kowalski/dask_clusters/dask_cluster_gcn.py
+directory = ./
+autostart = {{ enabled.gcn }}
+autorestart = True
+stdout_logfile = logs/dask_cluster_gcn.log
+stdout_logfile_maxbytes = 50MB
+redirect_stderr = True
+environment = PYTHONPATH=".", PRODUCTION=1
+
 [program:alert-broker-ztf]
 command = python kowalski/alert_brokers/alert_broker_ztf.py
 directory = ./
@@ -94,6 +104,16 @@ directory = ./
 autostart = {{ enabled.turbo }}
 autorestart = True
 stdout_logfile = logs/alert_broker_turbo.log
+stdout_logfile_maxbytes = 30MB
+redirect_stderr = True
+environment = PYTHONPATH=".", PRODUCTION=1
+
+[program:alert-broker-gcn]
+command = python kowalski/alert_brokers/alert_broker_gcn.py
+directory = ./
+autostart = {{ enabled.gcn }}
+autorestart = True
+stdout_logfile = logs/alert_broker_gcn.log
 stdout_logfile_maxbytes = 30MB
 redirect_stderr = True
 environment = PYTHONPATH=".", PRODUCTION=1

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -39,6 +39,20 @@ kowalski:
     zookeeper.test: "localhost:2181"
     path: "kafka_2.13-3.4.0"
 
+  gcn:
+    server: gcn.nasa.gov
+    client_group_id: null
+    client_id: null
+    client_secret: null
+    notice_types:
+      - FERMI_GBM_FIN_POS
+      - FERMI_GBM_SUBTHRESH
+      - LVC_PRELIMINARY
+      - LVC_INITIAL
+      - LVC_UPDATE
+      - LVC_RETRACTION
+      - LVC_TEST
+
   database:
     max_pool_size: 200
     host: "localhost"
@@ -67,6 +81,8 @@ kowalski:
       alerts_wntr_aux: "WNTR_alerts_aux"
       alerts_turbo: "TURBO_alerts"
       alerts_turbo_aux: "TURBO_alerts_aux"
+      alerts_gcn: "GCN_alerts"
+      alerts_gcn_aux: "GCN_alerts_aux"
 
     indexes:
       ZTF_alerts:
@@ -319,6 +335,29 @@ kowalski:
             - ["candidate.jd", -1]
             - ["candidate.scorr", -1]
             - ["candidate.dmag2mass", -1]
+          unique: false
+
+      GCN_alerts:
+        - name: dateobs
+          fields:
+            - ["dateobs", -1]
+          unique: true
+
+      GCN_alerts_aux:
+        - name: center_dateobs
+          fields:
+            - ["center", "2dsphere"]
+            - ["dateobs", -1]
+          unique: false
+        - name: contour50_dateobs
+          fields:
+            - ["contour50", "2dsphere"]
+            - ["dateobs", -1]
+          unique: false
+        - name: contour90_dateobs
+          fields:
+            - ["contour90", "2dsphere"]
+            - ["dateobs", -1]
           unique: false
 
     filters:
@@ -1107,6 +1146,16 @@ kowalski:
     lifetime_stagger: 1 hours
     lifetime_restart: true
 
+  dask_gcn:
+    host: 127.0.0.1
+    scheduler_port: 8792
+    dashboard_address: :8793
+    n_workers: 4
+    threads_per_worker: 1
+    lifetime: 24 hours
+    lifetime_stagger: 1 hours
+    lifetime_restart: true
+
   misc:
     # working stand-alone or in conjunction with a SkyPortal instance?
     broker: False
@@ -1127,3 +1176,4 @@ kowalski:
     pgir: True
     wntr: True
     turbo: True
+    gcn: True

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -341,23 +341,21 @@ kowalski:
         - name: dateobs
           fields:
             - ["dateobs", -1]
-          unique: true
-
-      GCN_alerts_aux:
-        - name: center_dateobs
-          fields:
-            - ["center", "2dsphere"]
-            - ["dateobs", -1]
           unique: false
-        - name: contour50_dateobs
+        - name: dateobs_center
           fields:
-            - ["contour50", "2dsphere"]
             - ["dateobs", -1]
+            - ["localization.center", "2dsphere"]
           unique: false
-        - name: contour90_dateobs
+        - name: dateobs_contour50
           fields:
-            - ["contour90", "2dsphere"]
             - ["dateobs", -1]
+            - ["localization.contour50", "2dsphere"]
+          unique: false
+        - name: dateobs_contour90
+          fields:
+            - ["dateobs", -1]
+            - ["localization.contour90", "2dsphere"]
           unique: false
 
     filters:
@@ -762,6 +760,14 @@ kowalski:
             zMeanPSFMagErr: 1
             yMeanPSFMag: 1
             yMeanPSFMagErr: 1
+
+        GCN_alerts:
+          type: "localization"
+          contour: "contour90"
+          filter: {}
+          projection:
+            _id: 1
+            dateobs: 1
 
       PGIR:
         2MASS_PSC:

--- a/data/gcn_notices/GCN.xml
+++ b/data/gcn_notices/GCN.xml
@@ -1,0 +1,112 @@
+<?xml version = '1.0' encoding = 'UTF-8'?>
+<voe:VOEvent
+      ivorn="ivo://nasa.gsfc.gcn/Fermi#GBM_Fin_Pos2023-03-28T13:58:24.25_701704709_0-451"
+      role="observation" version="2.0"
+      xmlns:voe="http://www.ivoa.net/xml/VOEvent/v2.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.ivoa.net/xml/VOEvent/v2.0  http://www.ivoa.net/xml/VOEvent/VOEvent-v2.0.xsd" >
+  <Who>
+    <AuthorIVORN>ivo://nasa.gsfc.tan/gcn</AuthorIVORN>
+    <Author>
+      <shortName>Fermi (via VO-GCN)</shortName>
+      <contactName>Julie McEnery</contactName>
+      <contactPhone>+1-301-286-1632</contactPhone>
+      <contactEmail>Julie.E.McEnery@nasa.gov</contactEmail>
+    </Author>
+    <Date>2020-01-25T09:49:00.004165</Date>
+    <Description>This VOEvent message was created with GCN VOE version: 15.08 17jun22</Description>
+  </Who>
+  <What>
+    <Param name="Packet_Type"    value="115" />
+    <Param name="Pkt_Ser_Num"    value="1" />
+    <Param name="TrigID"         value="701704709" ucd="meta.id" />
+    <Param name="Sequence_Num"   value="0" ucd="meta.id.part" />
+    <Param name="Burst_TJD"      value="20031" unit="days" ucd="time" />
+    <Param name="Burst_SOD"      value="50304.25" unit="sec" ucd="time" />
+    <Param name="Burst_Inten"    value="0" unit="cts" ucd="phot.count" />
+    <Param name="Data_Integ"     value="0.000" unit="sec" ucd="time.interval" />
+    <Param name="Burst_Signif"   value="0.00" unit="sigma" ucd="stat.snr" />
+    <Param name="Phi"            value="171.00" unit="deg" ucd="pos.az.azi" />
+    <Param name="Theta"          value="47.00" unit="deg" ucd="pos.az.zd" />
+    <Param name="Algorithm"      value="41731" unit="dn" />
+    <Param name="Lo_Energy"      value="44032" unit="keV"  />
+    <Param name="Hi_Energy"      value="279965" unit="keV"  />
+    <Param name="Trigger_ID"     value="0x00000000" />
+    <Param name="Misc_flags"     value="0x40000000" />
+    <Group name="Trigger_ID" >
+      <Param name="Def_NOT_a_GRB"         value="false" />
+      <Param name="Target_in_Blk_Catalog" value="false" />
+      <Param name="Human_generated"       value="false" />
+      <Param name="Robo_generated"        value="true" />
+      <Param name="Long_short"            value="unknown" />
+      <Param name="Spatial_Prox_Match"    value="false" />
+      <Param name="Temporal_Prox_Match"   value="false" />
+      <Param name="Test_Submission"       value="false" />
+    </Group>
+    <Group name="Misc_Flags" >
+      <Param name="Values_Out_of_Range"   value="false" />
+      <Param name="Flt_Generated"         value="false" />
+      <Param name="Gnd_Generated"         value="true" />
+      <Param name="CRC_Error"             value="false" />
+    </Group>
+    <Param name="LightCurve_URL" value="http://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/triggers/2023/bn230328582/quicklook/glg_lc_medres34_bn230328582.gif" ucd="meta.ref.url" />
+    <Param name="Coords_Type"    value="1" unit="dn" />
+    <Param name="Coords_String"  value="source_object" />
+    <Group name="Obs_Support_Info" >
+      <Description>The Sun and Moon values are valid at the time the VOEvent XML message was created.</Description>
+      <Param name="Sun_RA"        value="7.02" unit="deg" ucd="pos.eq.ra" />
+      <Param name="Sun_Dec"       value="3.03" unit="deg" ucd="pos.eq.dec" />
+      <Param name="Sun_Distance"  value="169.11" unit="deg" ucd="pos.angDistance" />
+      <Param name="Sun_Hr_Angle"  value="11.33" unit="hr" />
+      <Param name="Moon_RA"       value="92.19" unit="deg" ucd="pos.eq.ra" />
+      <Param name="Moon_Dec"      value="27.85" unit="deg" ucd="pos.eq.dec" />
+      <Param name="MOON_Distance" value="102.68" unit="deg" ucd="pos.angDistance" />
+      <Param name="Moon_Illum"    value="45.21" unit="%" ucd="arith.ratio" />
+      <Param name="Galactic_Long" value="311.93" unit="deg" ucd="pos.galactic.lon" />
+      <Param name="Galactic_Lat"  value="63.73" unit="deg" ucd="pos.galactic.lat" />
+      <Param name="Ecliptic_Long" value="195.07" unit="deg" ucd="pos.ecliptic.lon" />
+      <Param name="Ecliptic_Lat"  value="7.67" unit="deg" ucd="pos.ecliptic.lat" />
+    </Group>
+    <Description>The Fermi-GBM location of a transient.</Description>
+  </What>
+  <WhereWhen>
+    <ObsDataLocation>
+      <ObservatoryLocation id="GEOLUN" />
+      <ObservationLocation>
+        <AstroCoordSystem id="UTC-FK5-GEO" />
+        <AstroCoords coord_system_id="UTC-FK5-GEO">
+          <Time unit="s">
+            <TimeInstant>
+              <ISOTime>2020-01-25 09:49:00.004165</ISOTime>
+            </TimeInstant>
+          </Time>
+          <Position2D unit="deg">
+            <Name1>RA</Name1>
+            <Name2>Dec</Name2>
+            <Value2>
+              <C1>210.1000</C1>
+              <C2>64.2200</C2>
+            </Value2>
+            <Error2Radius>8.4400</Error2Radius>
+          </Position2D>
+        </AstroCoords>
+      </ObservationLocation>
+    </ObsDataLocation>
+  <Description>The RA,Dec coordinates are of the type: source_object.</Description>
+  </WhereWhen>
+  <How>
+    <Description>Fermi Satellite, GBM Instrument</Description>
+    <Reference uri="http://gcn.gsfc.nasa.gov/fermi.html" type="url" />
+  </How>
+  <Why importance="0.95">
+    <Inference probability="1.0">
+      <Concept>process.variation.burst;em.gamma</Concept>
+    </Inference>
+  </Why>
+  <Citations>
+    <EventIVORN cite="followup">ivo://nasa.gsfc.gcn/Fermi#GBM_Alert_2023-03-28T13:58:24.25_701704709_1-418</EventIVORN>
+    <Description>This is an updated position to the original trigger.</Description>
+  </Citations>
+  <Description>
+  </Description>
+</voe:VOEvent>

--- a/data/schema/VOEvent-v2.0.xsd
+++ b/data/schema/VOEvent-v2.0.xsd
@@ -1,0 +1,423 @@
+<?xml version='1.0' encoding='ASCII'?>
+<xs:schema xmlns="http://www.ivoa.net/xml/VOEvent/v2.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.ivoa.net/xml/VOEvent/v2.0" elementFormDefault="unqualified">
+
+  <xs:element name="VOEvent">
+    <xs:annotation>
+      <xs:documentation> VOEvent is the root element for describing observations of immediate
+        astronomical events. For more information, see
+        http://www.ivoa.net/twiki/bin/view/IVOA/IvoaVOEvent. The event consists of at most one of
+        each of: Who, What, WhereWhen, How, Why, Citations, Description, and
+        Reference.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <!-- Can have zero or one of each of these, in any order -->
+      <xs:all>
+        <xs:element name="Who" type="Who" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="What" type="What" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="WhereWhen" type="WhereWhen" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="How" type="How" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="Why" type="Why" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="Citations" type="Citations" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="Description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="Reference" type="Reference" minOccurs="0" maxOccurs="1"/>
+      </xs:all>
+      <xs:attribute name="version" type="xs:token" fixed="2.0" use="required"/>
+      <xs:attribute name="ivorn" type="xs:anyURI" use="required"/>
+      <xs:attribute name="role" type="roleValues" default="observation"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:simpleType name="roleValues">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="observation"/>
+      <xs:enumeration value="prediction"/>
+      <xs:enumeration value="utility"/>
+      <xs:enumeration value="test"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+
+  <xs:complexType name="Who">
+    <xs:annotation>
+      <xs:documentation> Who: Curation Metadata </xs:documentation>
+    </xs:annotation>
+    <xs:all>
+      <!-- Can have zero or one of each of these. Schema is loose because
+        should have AuthorIVORN *or* Author -->
+      <xs:element name="AuthorIVORN" type="xs:anyURI" minOccurs="0"/>
+      <xs:element name="Date" type="xs:dateTime" minOccurs="0"/>
+      <xs:element name="Description" type="xs:string" minOccurs="0"/>
+      <xs:element name="Reference" type="Reference" minOccurs="0"/>
+      <xs:element name="Author" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation> Author information follows the IVOA curation information schema: the
+            organization responsible for the packet can have a title, short name or acronym, and a
+            logo. A contact person has a name, email, and phone number. Other contributors can also
+            be noted. </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:choice maxOccurs="unbounded">
+            <xs:element name="title" type="xs:string"/>
+            <xs:element name="shortName" type="xs:string"/>
+            <xs:element name="logoURL" type="xs:anyURI"/>
+            <xs:element name="contactName" type="xs:string"/>
+            <xs:element name="contactEmail" type="xs:string"/>
+            <xs:element name="contactPhone" type="xs:string"/>
+            <xs:element name="contributor" type="xs:string"/>
+          </xs:choice>
+        </xs:complexType>
+      </xs:element>
+    </xs:all>
+  </xs:complexType>
+
+
+  <xs:complexType name="What">
+    <xs:annotation>
+      <xs:documentation> What: Event Characterization. This is the part of the data model that is
+        chosen by the Authoer of the event rather than the IVOA. There can be Params, that may be in
+        Groups, and Tables, and simpleTimeSeries. There can also be Description and Reference as
+        with most VOEvent elements. </xs:documentation>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded">
+      <!-- can have any number of any of these in any order  -->
+      <xs:element name="Param" type="Param" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="Group" type="Group" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="Table" type="Table" minOccurs="0" maxOccurs="unbounded"/>
+      <!--<xs:element ref="sts:SimpleTimeseries"          minOccurs="0" maxOccurs="unbounded"/>-->
+      <xs:element name="Description" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="Reference" type="Reference" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:choice>
+  </xs:complexType>
+
+
+  <xs:complexType name="Param">
+    <xs:annotation>
+      <xs:documentation> What/Param definition. A Param has name, value, ucd, unit, dataType; and
+        may have Description and Reference.</xs:documentation>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="Description" type="xs:string" minOccurs="0"/>
+      <xs:element name="Reference" type="Reference" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="Value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:choice>
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="ucd" type="xs:string"/>
+    <xs:attribute name="value" type="xs:string"/>
+    <xs:attribute name="unit" type="xs:string"/>
+    <xs:attribute name="dataType" type="dataType" default="string"/>
+    <xs:attribute name="utype" type="xs:string"/>
+  </xs:complexType>
+  <xs:simpleType name="dataType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="string"/>
+      <xs:enumeration value="float"/>
+      <xs:enumeration value="int"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="Group">
+    <xs:annotation>
+      <xs:documentation> What/Group definition: A group is a collection of Params, with name and
+        type attributes.</xs:documentation>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="Param" type="Param" maxOccurs="unbounded"/>
+      <xs:element name="Description" type="xs:string" minOccurs="0"/>
+      <xs:element name="Reference" type="Reference" minOccurs="0"/>
+    </xs:choice>
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="type" type="xs:string"/>
+  </xs:complexType>
+
+
+  <xs:complexType name="Table">
+    <xs:annotation>
+      <xs:documentation> What/Table definition. This small Table has Fields for the column
+        definitions, and Data to hold the table data, with TR for row and TD for value of a table
+        cell.</xs:documentation>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="Description" type="xs:string" minOccurs="0"/>
+      <xs:element name="Reference" type="Reference" minOccurs="0"/>
+      <xs:element name="Param" type="Param" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="Field" type="Field" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="Data" type="Data" minOccurs="1" maxOccurs="1"/>
+    </xs:choice>
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="type" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="Field">
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="Description" type="xs:string" minOccurs="0"/>
+      <xs:element name="Reference" type="Reference" minOccurs="0"/>
+    </xs:choice>
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="ucd" type="xs:string"/>
+    <xs:attribute name="unit" type="xs:string"/>
+    <xs:attribute name="dataType" type="dataType" default="string"/>
+    <xs:attribute name="utype" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="Data">
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="TR" type="TR"/>
+    </xs:choice>
+  </xs:complexType>
+  <xs:complexType name="TR">
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="TD" type="xs:string"/>
+    </xs:choice>
+  </xs:complexType>
+
+
+  <xs:complexType name="WhereWhen">
+    <xs:annotation>
+      <xs:documentation> WhereWhen: Space-Time Coordinates. Lots and lots of elements here, but the
+        import is that each event has these: observatory, coord_system, time, timeError, longitude,
+        latitude, posError.</xs:documentation>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="ObsDataLocation" type="ObsDataLocation" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Description" type="xs:string" minOccurs="0"/>
+      <xs:element name="Reference" type="Reference" minOccurs="0"/>
+    </xs:choice>
+    <xs:attribute name="id" type="xs:ID" use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="ObsDataLocation">
+    <xs:annotation>
+      <xs:documentation> Part of WhereWhen</xs:documentation>
+    </xs:annotation>
+    <xs:all>
+      <xs:element name="ObservatoryLocation" minOccurs="1" maxOccurs="1" type="ObservatoryLocation"/>
+      <xs:element name="ObservationLocation" minOccurs="1" maxOccurs="1" type="ObservationLocation"/>
+    </xs:all>
+  </xs:complexType>
+
+  <xs:complexType name="ObservationLocation">
+    <xs:annotation>
+      <xs:documentation> Part of WhereWhen</xs:documentation>
+    </xs:annotation>
+    <xs:all>
+      <xs:element name="AstroCoordSystem" type="AstroCoordSystem" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="AstroCoords" type="AstroCoords" minOccurs="1" maxOccurs="1"/>
+    </xs:all>
+  </xs:complexType>
+
+  <xs:complexType name="AstroCoordSystem">
+    <xs:annotation>
+      <xs:documentation> Part of WhereWhen</xs:documentation>
+    </xs:annotation>
+    <!-- The empty sequence closes this to content -->
+    <xs:sequence/>
+    <xs:attribute name="id" type="idValues"/>
+  </xs:complexType>
+  <xs:simpleType name="idValues">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="TT-ICRS-TOPO"/>
+      <xs:enumeration value="UTC-ICRS-TOPO"/>
+      <xs:enumeration value="TT-FK5-TOPO"/>
+      <xs:enumeration value="UTC-FK5-TOPO"/>
+      <xs:enumeration value="GPS-ICRS-TOPO"/>
+      <xs:enumeration value="GPS-ICRS-TOPO"/>
+      <xs:enumeration value="GPS-FK5-TOPO"/>
+      <xs:enumeration value="GPS-FK5-TOPO"/>
+      <xs:enumeration value="TT-ICRS-GEO"/>
+      <xs:enumeration value="UTC-ICRS-GEO"/>
+      <xs:enumeration value="TT-FK5-GEO"/>
+      <xs:enumeration value="UTC-FK5-GEO"/>
+      <xs:enumeration value="GPS-ICRS-GEO"/>
+      <xs:enumeration value="GPS-ICRS-GEO"/>
+      <xs:enumeration value="TDB-ICRS-BARY"/>
+      <xs:enumeration value="TDB-FK5-BARY"/>
+      <!-- this one for ObservatoryLocation -->
+      <xs:enumeration value="UTC-GEOD-TOPO"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="AstroCoords">
+    <xs:annotation>
+      <xs:documentation> Part of WhereWhen</xs:documentation>
+    </xs:annotation>
+    <xs:all>
+      <xs:element name="Time" type="Time" minOccurs="0"/>
+      <xs:element name="Position2D" type="Position2D" minOccurs="0"/>
+      <xs:element name="Position3D" type="Position3D" minOccurs="0"/>
+    </xs:all>
+    <xs:attribute name="coord_system_id" type="idValues"/>
+  </xs:complexType>
+
+  <xs:complexType name="Time">
+    <xs:annotation>
+      <xs:documentation> Part of WhereWhen</xs:documentation>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="TimeInstant" type="TimeInstant"/>
+      <xs:element name="Error" type="xs:float" minOccurs="0"/>
+    </xs:choice>
+    <xs:attribute name="unit" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="TimeInstant">
+    <xs:annotation>
+      <xs:documentation> Part of WhereWhen</xs:documentation>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="ISOTime" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="TimeOffset" type="xs:float" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="TimeScale" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="Position2D">
+    <xs:annotation>
+      <xs:documentation> Part of WhereWhen</xs:documentation>
+    </xs:annotation>
+    <xs:all>
+      <xs:element name="Name1" type="xs:string" minOccurs="0"/>
+      <xs:element name="Name2" type="xs:string" minOccurs="0"/>
+      <xs:element name="Value2" type="Value2"/>
+      <xs:element name="Error2Radius" type="xs:float"/>
+    </xs:all>
+    <xs:attribute name="unit" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="Position3D">
+    <xs:annotation>
+      <xs:documentation> Part of WhereWhen</xs:documentation>
+    </xs:annotation>
+    <xs:all>
+      <xs:element name="Name1" type="xs:string" minOccurs="0"/>
+      <xs:element name="Name2" type="xs:string" minOccurs="0"/>
+      <xs:element name="Name3" type="xs:string" minOccurs="0"/>
+      <xs:element name="Value3" type="Value3"/>
+    </xs:all>
+    <xs:attribute name="unit" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="Value2">
+    <xs:annotation>
+      <xs:documentation> Part of WhereWhen</xs:documentation>
+    </xs:annotation>
+    <xs:all>
+      <xs:element name="C1" type="xs:float"/>
+      <xs:element name="C2" type="xs:float"/>
+    </xs:all>
+  </xs:complexType>
+
+  <xs:complexType name="Value3">
+    <xs:annotation>
+      <xs:documentation> Part of WhereWhen</xs:documentation>
+    </xs:annotation>
+    <xs:all>
+      <xs:element name="C1" type="xs:float"/>
+      <xs:element name="C2" type="xs:float"/>
+      <xs:element name="C3" type="xs:float"/>
+    </xs:all>
+  </xs:complexType>
+
+  <xs:complexType name="ObservatoryLocation">
+    <xs:annotation>
+      <xs:documentation> Part of WhereWhen</xs:documentation>
+    </xs:annotation>
+    <xs:all>
+      <xs:element name="AstroCoordSystem" type="AstroCoordSystem" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="AstroCoords" type="AstroCoords" minOccurs="0" maxOccurs="1"/>
+    </xs:all>
+    <xs:attribute name="id" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="How">
+    <xs:annotation>
+      <xs:documentation> How: Instrument Configuration. Built with some Description and Reference
+        elements. </xs:documentation>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="Description" type="xs:string"/>
+      <xs:element name="Reference" type="Reference"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="Why">
+    <xs:annotation>
+      <xs:documentation> Why: Initial Scientific Assessment. Can make simple Concept/Name/Desc/Ref
+        for the inference or use multiple Inference containers for more semantic sophistication.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="Name" type="xs:string"/>
+      <xs:element name="Concept" type="xs:string"/>
+      <xs:element name="Inference" type="Inference"/>
+      <xs:element name="Description" type="xs:string"/>
+      <xs:element name="Reference" type="Reference"/>
+    </xs:choice>
+    <xs:attribute name="importance" type="xs:float"/>
+    <xs:attribute name="expires" type="xs:dateTime"/>
+  </xs:complexType>
+
+  <xs:complexType name="Inference">
+    <xs:annotation>
+      <xs:documentation> Why/Inference: A container for a more nuanced expression, including
+        relationships and probability. </xs:documentation>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="Name" type="xs:string"/>
+      <xs:element name="Concept" type="xs:string"/>
+      <xs:element name="Description" type="xs:string"/>
+      <xs:element name="Reference" type="Reference"/>
+    </xs:choice>
+    <xs:attribute name="probability" type="smallFloat"/>
+    <xs:attribute name="relation" type="xs:string"/>
+  </xs:complexType>
+  <xs:simpleType name="smallFloat">
+    <xs:restriction base="xs:float">
+      <xs:minInclusive value="0.0"/>
+      <xs:maxInclusive value="1.0"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+
+  <xs:complexType name="Citations">
+    <xs:annotation>
+      <xs:documentation> Citations: Follow-up Observations. This section is a sequence of EventIVORN
+        elements, each of which has the IVORN of a cited event. </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="EventIVORN" type="EventIVORN" maxOccurs="unbounded"/>
+      <xs:element name="Description" type="xs:string" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="EventIVORN">
+    <xs:annotation>
+      <xs:documentation> Citations/EventIVORN. The value is the IVORN of the cited event, the 'cite'
+        attribute is the nature of that relationship, choosing from 'followup', 'supersedes', or
+        'retraction'.</xs:documentation>
+    </xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="cite" type="citeValues"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:simpleType name="citeValues">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="followup"/>
+      <xs:enumeration value="supersedes"/>
+      <xs:enumeration value="retraction"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="Reference">
+    <xs:annotation>
+      <xs:documentation> Reference: External Content. The payload is the uri, and the 'type'
+        describes the nature of the data under that uri. The Reference can also be named.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence/>
+    <xs:attribute name="uri" type="xs:anyURI" use="required"/>
+    <xs:attribute name="type" type="xs:string"/>
+    <xs:attribute name="mimetype" type="xs:string"/>
+    <xs:attribute name="meaning" type="xs:anyURI"/>
+  </xs:complexType>
+
+</xs:schema>

--- a/kowalski/alert_brokers/alert_broker_gcn.py
+++ b/kowalski/alert_brokers/alert_broker_gcn.py
@@ -1,0 +1,440 @@
+__all__ = ["GCNAlertConsumer", "GCNAlertWorker", "EopError"]
+
+import datetime
+import os
+import traceback
+import uuid
+from typing import Mapping
+
+import certifi
+import confluent_kafka
+import dask.distributed
+import lxml
+import xmlschema
+from authlib.integrations.requests_client import OAuth2Session
+
+from kowalski.config import load_config
+from kowalski.log import log
+from kowalski.tools.gcn_utils import (
+    from_cone,
+    from_url,
+    get_contour,
+    get_dateobs,
+    get_skymap_metadata,
+    get_trigger,
+)
+from kowalski.utils import Mongo, time_stamp, timer
+
+# Tensorflow is problematic for Mac's currently, so we can add an option to disable it
+USE_TENSORFLOW = os.environ.get("USE_TENSORFLOW", True) in [
+    "True",
+    "t",
+    "true",
+    "1",
+    True,
+    1,
+]
+
+""" load config and secrets """
+config = load_config(config_files=["config.yaml"])["kowalski"]
+
+
+def set_oauth_cb(config):
+    """Implement client support for KIP-768 OpenID Connect.
+    Apache Kafka 3.1.0 supports authentication using OpenID Client Credentials.
+    Native support for Python is coming in the next release of librdkafka
+    (version 1.9.0). Meanwhile, this is a pure Python implementation of the
+    refresh token callback.
+    """
+    if config.pop("sasl.oauthbearer.method", None) != "oidc":
+        return
+
+    client_id = config.pop("sasl.oauthbearer.client.id")
+    client_secret = config.pop("sasl.oauthbearer.client.secret", None)
+    scope = config.pop("sasl.oauthbearer.scope", None)
+    token_endpoint = config.pop("sasl.oauthbearer.token.endpoint.url")
+
+    session = OAuth2Session(client_id, client_secret, scope=scope)
+
+    def oauth_cb(*_, **__):
+        token = session.fetch_token(token_endpoint, grant_type="client_credentials")
+        return token["access_token"], token["expires_at"]
+
+    config["oauth_cb"] = oauth_cb
+
+
+class EopError(Exception):
+    """
+    Exception raised when reaching end of a Kafka topic partition.
+    """
+
+    def __init__(self, msg):
+        """
+        :param msg: The Kafka message result from consumer.poll()
+        """
+        message = (
+            f"{time_stamp()}: topic:{msg.topic()}, partition:{msg.partition()}, "
+            f"status:end, offset:{msg.offset()}, key:{str(msg.key())}\n"
+        )
+        self.message = message
+
+    def __str__(self):
+        return self.message
+
+
+class GCNAlertConsumer:
+    """
+    Creates an alert stream Kafka consumer for a given topic.
+    """
+
+    def __init__(self, topics: list, dask_client: dask.distributed.Client, **kwargs):
+
+        self.verbose = kwargs.get("verbose", 2)
+
+        self.dask_client = dask_client
+
+        self.topics = topics
+
+        self.consumer = confluent_kafka.Consumer(**kwargs)
+        self.num_partitions = 0
+
+        def on_assign(consumer, partitions, _self=self):
+            # force-reset offsets when subscribing to a topic:
+            for part in partitions:
+                # -2 stands for beginning and -1 for end
+                part.offset = -2
+                # keep number of partitions.
+                # when reaching end of last partition, kill thread and start from beginning
+                _self.num_partitions += 1
+                log(consumer.get_watermark_offsets(part))
+
+        self.consumer.subscribe(topics, on_assign=on_assign)
+        log(f"Successfully subscribed to {len(topics)} topics: {topics}")
+
+        # set up own mongo client
+        self.collection_alerts = config["database"]["collections"]["alerts_gcn"]
+        self.collection_alerts_aux = config["database"]["collections"]["alerts_gcn_aux"]
+
+        self.mongo = Mongo(
+            host=config["database"]["host"],
+            port=config["database"]["port"],
+            replica_set=config["database"]["replica_set"],
+            username=config["database"]["username"],
+            password=config["database"]["password"],
+            db=config["database"]["db"],
+            srv=config["database"]["srv"],
+            verbose=self.verbose,
+        )
+
+        # create indexes
+        if config["database"]["build_indexes"]:
+            for index in config["database"]["indexes"][self.collection_alerts]:
+                try:
+                    ind = [tuple(ii) for ii in index["fields"]]
+                    self.mongo.db[self.collection_alerts].create_index(
+                        keys=ind,
+                        name=index["name"],
+                        background=True,
+                        unique=index["unique"],
+                    )
+                except Exception as e:
+                    log(e)
+
+            for index in config["database"]["indexes"][self.collection_alerts_aux]:
+                try:
+                    ind = [tuple(ii) for ii in index["fields"]]
+                    self.mongo.db[self.collection_alerts_aux].create_index(
+                        keys=ind,
+                        name=index["name"],
+                        background=True,
+                        unique=index["unique"],
+                    )
+                except Exception as e:
+                    log(e)
+
+        log("Finished AlertConsumer setup")
+
+    @classmethod
+    def decode_message(cls, msg):
+        """
+        Decode Avro message according to a schema.
+
+        :param msg: The Kafka message result from consumer.poll()
+        :return:
+        """
+        message = msg.value()
+        return message
+
+    @staticmethod
+    def process_alert(alert: Mapping, topic: str):
+        """Alert brokering task run by dask.distributed workers
+
+        :param alert: decoded alert from Kafka stream
+        :param topic: Kafka stream topic name for bookkeeping
+        :return:
+        """
+        schema = "data/schema/VOEvent-v2.0.xsd"
+        voevent_schema = xmlschema.XMLSchema(schema)
+        if voevent_schema.is_valid(alert):
+            # check if is string
+            try:
+                alert = alert.encode("ascii")
+            except AttributeError:
+                pass
+            root = lxml.etree.fromstring(alert)
+        else:
+            raise ValueError("xml file is not valid VOEvent")
+
+        dateobs = get_dateobs(root)
+        trigger = get_trigger(root)
+
+        notice_content = lxml.etree.tostring(root)
+
+        alert = {
+            "dateobs": dateobs,
+            "triggerid": trigger,
+            "date_created": datetime.datetime.utcnow(),
+        }
+
+        # get worker running current task
+        worker = dask.distributed.get_worker()
+        alert_worker = worker.plugins["worker-init"].alert_worker
+
+        # return if this alert packet has already been processed and ingested into collection_alerts:
+        if (
+            alert_worker.mongo.db[alert_worker.collection_alerts].count_documents(
+                {"triggerid": trigger, "dateobs": dateobs}, limit=1
+            )
+            == 1
+        ):
+            return
+
+        with timer(f"Ingesting {dateobs} - {trigger}", alert_worker.verbose > 1):
+            alert_worker.mongo.insert_one(
+                collection=alert_worker.collection_alerts, document=alert
+            )
+
+        alert_aux = {
+            "dateobs": dateobs,
+            "triggerid": trigger,
+            "notice_type": topic,
+            "notice_content": notice_content,
+            "date_created": datetime.datetime.utcnow(),
+        }
+
+        # we generate the skymap
+        with timer(
+            f"Generating skymap for {dateobs} - {trigger}", alert_worker.verbose > 1
+        ):
+            skymap = alert_worker.generate_skymap(root, topic)
+
+        # we ingest the skymap
+        # with timer(f"Mongofication of skymap for {dateobs} - {trigger}", alert_worker.verbose > 1):
+        #     skymap = alert_worker.skymap_mongify(skymap)
+
+        if skymap is not None:
+            # we generate the contour
+            with timer(
+                f"Generating contour for {dateobs} - {trigger}",
+                alert_worker.verbose > 1,
+            ):
+                contours = alert_worker.generate_contours(skymap)
+                alert_aux = {**alert_aux, **contours}
+
+            # we ingest the contour
+            with timer(
+                f"Ingesting skymap for {dateobs} - {trigger}", alert_worker.verbose > 1
+            ):
+                alert_worker.mongo.insert_one(
+                    collection=alert_worker.collection_alerts_aux, document=alert_aux
+                )
+
+        del skymap
+        del alert
+        del alert_aux
+
+    def poll(self):
+        """Polls Kafka broker to consume a topic."""
+        msg = self.consumer.poll()
+
+        if msg is None:
+            log("Caught error: msg is None")
+
+        if msg.error():
+            # reached end of topic
+            log(f"Caught error: {msg.error()}")
+            pass
+
+        elif msg is not None:
+            try:
+
+                msg_decoded = self.decode_message(msg)
+                topic = msg.topic()
+
+                with timer(
+                    f"Submitting alert from topic {topic} for processing",
+                    self.verbose > 1,
+                ):
+                    future = self.dask_client.submit(
+                        self.process_alert, msg_decoded, topic, pure=True
+                    )
+                    dask.distributed.fire_and_forget(future)
+                    future.release()
+                    del future
+
+            except Exception as e:
+                print("Error in poll!")
+                log(e)
+                _err = traceback.format_exc()
+                log(_err)
+
+
+class GCNAlertWorker:
+    """Tools to handle alert processing:
+    database ingestion, filtering, ml'ing, cross-matches, reporting to SP"""
+
+    def __init__(self, **kwargs):
+
+        self.verbose = kwargs.get("verbose", 2)
+        self.config = config
+
+        # MongoDB collections to store the alerts:
+        self.collection_alerts = self.config["database"]["collections"]["alerts_gcn"]
+        self.collection_alerts_aux = self.config["database"]["collections"][
+            "alerts_gcn_aux"
+        ]
+
+        self.mongo = Mongo(
+            host=config["database"]["host"],
+            port=config["database"]["port"],
+            replica_set=config["database"]["replica_set"],
+            username=config["database"]["username"],
+            password=config["database"]["password"],
+            db=config["database"]["db"],
+            srv=config["database"]["srv"],
+            verbose=self.verbose,
+        )
+
+    @staticmethod
+    def generate_skymap(root, notice_type):
+        """
+        Generate a skymap from an alert
+
+        :param alert:
+        :return:
+        """
+        status, skymap_metadata = get_skymap_metadata(root, notice_type)
+
+        if status == "available":
+            return from_url(skymap_metadata["url"])
+        elif status == "cone":
+            return from_cone(
+                ra=skymap_metadata["ra"],
+                dec=skymap_metadata["dec"],
+                error=skymap_metadata["error"],
+            )
+        else:
+            return None
+
+    @staticmethod
+    def generate_contours(skymap):
+        """
+        Generate a contour from a skymap
+
+        :param skymap:
+        :return:
+        """
+        contours = get_contour(skymap)
+        return {
+            "center": contours[0],
+            "contour50": contours[1],
+            "contour90": contours[2],
+        }
+
+
+class WorkerInitializer(dask.distributed.WorkerPlugin):
+    def __init__(self, *args, **kwargs):
+        self.alert_worker = None
+
+    def setup(self, worker: dask.distributed.Worker):
+        self.alert_worker = GCNAlertWorker()
+
+
+def topic_listener():
+    """Listen to a Kafka topic with GCN alerts
+    :return:
+    """
+
+    # first, we verify that there is a gcn key in the config
+    if "gcn" not in config:
+        raise ValueError("No GCN configuration found in config file")
+    # if there is no client_id and client_secret, we show a warning and exit
+    if "client_id" not in config["gcn"] or "client_secret" not in config["gcn"]:
+        log(
+            "No client_id or client_secret found in config file. Exiting the GCN alert broker."
+        )
+        return
+
+    # if there is no group_id, we generate one
+    if "client_group_id" not in config["gcn"]:
+        config["gcn"]["client_group_id"] = f"{str(uuid.uuid4())}"
+        log(
+            f"No client_group_id found in config file. Using a randomly generated one: {config['gcn']['client_group_id']} (entire alert stream will be reprocessed everytime)"
+        )
+
+    # Configure dask client
+    dask_client = dask.distributed.Client(
+        address=f"{config['dask_gcn']['host']}:{config['dask_gcn']['scheduler_port']}"
+    )
+
+    # init each worker with AlertWorker instance
+    worker_initializer = WorkerInitializer()
+    dask_client.register_worker_plugin(worker_initializer, name="worker-init")
+    # Configure consumer connection to Kafka broker
+    domain = config["gcn"]["server"]
+    topics = [
+        f"gcn.classic.voevent.{notice_type}"
+        for notice_type in config["gcn"]["notice_types"]
+    ]
+
+    conf = {
+        "security.protocol": "sasl_ssl",
+        "ssl.ca.location": certifi.where(),
+        "bootstrap.servers": f"kafka.{domain}",
+        "sasl.mechanisms": "OAUTHBEARER",
+        "sasl.oauthbearer.method": "oidc",
+        "sasl.oauthbearer.client.id": config["gcn"]["client_id"],
+        "sasl.oauthbearer.client.secret": config["gcn"]["client_secret"],
+        "sasl.oauthbearer.token.endpoint.url": f"https://auth.{domain}/oauth2/token",
+        "auto.offset.reset": "earliest",
+        "enable.auto.commit": False,
+        "group.id": config["gcn"]["client_group_id"],
+    }
+
+    set_oauth_cb(conf)
+
+    # Start alert stream consumer
+    stream_reader = GCNAlertConsumer(topics, dask_client, **conf)
+
+    while True:
+        try:
+            # poll!
+            stream_reader.poll()
+        except Exception as e:
+            log(e)
+            _err = traceback.format_exc()
+            log(_err)
+            break
+
+
+if __name__ == "__main__":
+    topic_listener()
+
+# TODO: CROSSMATCH ALERTS WITH THAT COLLECTION, USING THAT QUERY:
+# {
+#   'contour50': {'$geoIntersects': {'$geometry': [-152, 68]}},
+#   'dateobs': {
+#       '$lte': ISODate('2023-03-25'),
+#       '$gte': ISODate('2023-03-19')
+#   }
+# }

--- a/kowalski/alert_brokers/alert_broker_pgir.py
+++ b/kowalski/alert_brokers/alert_broker_pgir.py
@@ -86,7 +86,7 @@ class PGIRAlertConsumer(AlertConsumer, ABC):
             with timer(
                 f"Cross-match of {object_id} {candid}", alert_worker.verbose > 1
             ):
-                xmatches = alert_worker.alert_filter__xmatch(alert)
+                xmatches = alert_worker.alert_filter__xmatch(alert, prv_candidates)
             # CLU cross-match:
             with timer(
                 f"CLU cross-match {object_id} {candid}", alert_worker.verbose > 1

--- a/kowalski/alert_brokers/alert_broker_turbo.py
+++ b/kowalski/alert_brokers/alert_broker_turbo.py
@@ -86,7 +86,7 @@ class TURBOAlertConsumer(AlertConsumer, ABC):
             with timer(
                 f"Cross-match of {object_id} {candid}", alert_worker.verbose > 1
             ):
-                xmatches = alert_worker.alert_filter__xmatch(alert)
+                xmatches = alert_worker.alert_filter__xmatch(alert, prv_candidates)
             # CLU cross-match:
             with timer(
                 f"CLU cross-match {object_id} {candid}", alert_worker.verbose > 1

--- a/kowalski/alert_brokers/alert_broker_winter.py
+++ b/kowalski/alert_brokers/alert_broker_winter.py
@@ -104,7 +104,7 @@ class WNTRAlertConsumer(AlertConsumer, ABC):
             with timer(
                 f"Cross-match of {object_id} {candid}", alert_worker.verbose > 1
             ):
-                xmatches = alert_worker.alert_filter__xmatch(alert)
+                xmatches = alert_worker.alert_filter__xmatch(alert, prv_candidates)
             # CLU cross-match:
             with timer(
                 f"CLU cross-match {object_id} {candid}", alert_worker.verbose > 1

--- a/kowalski/alert_brokers/alert_broker_ztf.py
+++ b/kowalski/alert_brokers/alert_broker_ztf.py
@@ -86,7 +86,7 @@ class ZTFAlertConsumer(AlertConsumer, ABC):
             with timer(
                 f"Cross-match of {object_id} {candid}", alert_worker.verbose > 1
             ):
-                xmatches = alert_worker.alert_filter__xmatch(alert)
+                xmatches = alert_worker.alert_filter__xmatch(alert, prv_candidates)
             # CLU cross-match:
             with timer(
                 f"CLU cross-match {object_id} {candid}", alert_worker.verbose > 1

--- a/kowalski/api.py
+++ b/kowalski/api.py
@@ -2406,7 +2406,7 @@ class ZTFMMATriggerHandler(Handler):
         ZTFMMATriggerGet(**_data)
 
         if self.test:
-            return self.success(message="submitted")
+            return self.success(message="submitted", data=[{"trigger_name": "test"}])
 
         server = SSHTunnelForwarder(
             (config["ztf"]["mountain_ip"], config["ztf"]["mountain_port"]),

--- a/kowalski/api.py
+++ b/kowalski/api.py
@@ -2116,7 +2116,7 @@ class ZTFTriggerGet(Model, ABC):
     """Data model for ZTF queue retrieval for streamlined validation"""
 
     queue_name: Optional[str]
-    user: str
+    user: Optional[str]
 
 
 class ZTFTriggerDelete(Model, ABC):
@@ -2174,9 +2174,8 @@ class ZTFTriggerHandler(Handler):
 
         # validate
         ZTFTriggerGet(**_data)
-
         if self.test:
-            return self.success(message="submitted")
+            return self.success(message="submitted", data=[{"queue_name": "test"}])
 
         server = SSHTunnelForwarder(
             (config["ztf"]["mountain_ip"], config["ztf"]["mountain_port"]),
@@ -2347,7 +2346,7 @@ class ZTFMMATriggerGet(Model, ABC):
     """Data model for ZTF MMA trigger retrieval for streamlined validation"""
 
     trigger_name: Optional[str]
-    user: str
+    user: Optional[str]
 
 
 class ZTFMMATriggerDelete(Model, ABC):

--- a/kowalski/api.py
+++ b/kowalski/api.py
@@ -3165,7 +3165,7 @@ async def app_factory():
     filter_handler = FilterHandler()
     ztf_trigger_handler = ZTFTriggerHandler()
     ztf_trigger_handler_test = ZTFTriggerHandler(test=True)
-    ztf_mma_trigger_handler = ZTFMMATriggerHandler
+    ztf_mma_trigger_handler = ZTFMMATriggerHandler()
     ztf_mma_trigger_handler_test = ZTFMMATriggerHandler(test=True)
 
     # add routes manually

--- a/kowalski/dask_clusters/dask_cluster_gcn.py
+++ b/kowalski/dask_clusters/dask_cluster_gcn.py
@@ -1,0 +1,27 @@
+import time
+
+from dask.distributed import LocalCluster
+from kowalski.config import load_config
+from kowalski.log import log
+from kowalski.alert_brokers.alert_broker_gcn import WorkerInitializer  # noqa: F401
+
+""" load config and secrets """
+config = load_config(config_files=["config.yaml"])["kowalski"]
+
+
+if __name__ == "__main__":
+
+    cluster = LocalCluster(
+        threads_per_worker=config["dask_gcn"]["threads_per_worker"],
+        n_workers=config["dask_gcn"]["n_workers"],
+        scheduler_port=config["dask_gcn"]["scheduler_port"],
+        dashboard_address=config["dask_gcn"]["dashboard_address"],
+        lifetime=config["dask_gcn"]["lifetime"],
+        lifetime_stagger=config["dask_gcn"]["lifetime_stagger"],
+        lifetime_restart=config["dask_gcn"]["lifetime_restart"],
+    )
+    log(cluster)
+
+    while True:
+        time.sleep(60)
+        log("Heartbeat")

--- a/kowalski/tests/test_alert_broker_gcn.py
+++ b/kowalski/tests/test_alert_broker_gcn.py
@@ -1,0 +1,166 @@
+import datetime
+
+import pytest
+import lxml
+import xmlschema
+
+from kowalski.alert_brokers.alert_broker_gcn import GCNAlertWorker
+from kowalski.config import load_config
+from kowalski.log import log
+from kowalski.tools.gcn_utils import get_dateobs, get_trigger
+
+""" load config and secrets """
+config = load_config(config_files=["config.yaml"])["kowalski"]
+
+
+@pytest.fixture(autouse=True, scope="class")
+def worker_fixture(request):
+    log("Initializing alert processing worker class instance")
+    request.cls.worker = GCNAlertWorker()
+    log("Successfully initialized")
+    # do not attempt monitoring filters
+    request.cls.run_forever = False
+
+
+@pytest.fixture(autouse=True, scope="class")
+def alert_fixture(request):
+    log("Loading a sample GCN notice")
+    notice = "GCN"
+    request.cls.notice_name = notice
+    sample_avro = f"data/gcn_notices/{notice}.xml"
+    print("sample_avro", sample_avro)
+    with open(sample_avro, "r") as f:
+        alert = f.read()
+        schema = "data/schema/VOEvent-v2.0.xsd"
+        voevent_schema = xmlschema.XMLSchema(schema)
+        if voevent_schema.is_valid(alert):
+            # check if is string
+            try:
+                alert = alert.encode("ascii")
+            except AttributeError:
+                pass
+            root = lxml.etree.fromstring(alert)
+        else:
+            raise ValueError("xml file is not valid VOEvent")
+
+        dateobs = get_dateobs(root)
+        triggerid = get_trigger(root)
+        alert = {
+            "dateobs": dateobs,
+            "triggerid": triggerid,
+            "notice_type": "gcn.classic.voevent.FERMI_GBM_FIN_POS",
+            "notice_content": lxml.etree.tostring(root),
+            "date_created": datetime.datetime.utcnow(),
+        }
+        request.cls.alert = alert
+        request.cls.root = root
+
+
+class TestAlertBrokerGCN:
+    """Test individual components/methods of the GCN alert processor used by the broker"""
+
+    def test_generate_skymap(self):
+        """Test generating a skymap from the alert"""
+        skymap = self.worker.generate_skymap(self.root, self.alert["notice_type"])
+        assert skymap is not None
+        assert type(skymap) == dict
+
+    def test_generate_contours(self):
+        """Test generating contours from the alert"""
+        skymap = self.worker.generate_skymap(self.root, self.alert["notice_type"])
+        assert skymap is not None
+        contours = self.worker.generate_contours(skymap)
+        assert contours is not None
+        assert type(contours) == dict
+        assert "center" in contours
+        assert "contour50" in contours
+        assert "contour90" in contours
+
+    def test_crossmatch_gcn_with_point(self):
+        """Test crossmatching a GCN alert with a point source"""
+        skymap = self.worker.generate_skymap(self.root, self.alert["notice_type"])
+        assert skymap is not None
+        contours = self.worker.generate_contours(skymap)
+        assert contours is not None
+        alert = self.alert
+        alert["localization"] = contours
+
+        # if there is already an alert in the database, delete it
+        self.worker.mongo.db[self.worker.collection_alerts].delete_many(
+            {"dateobs": alert["dateobs"], "triggerid": alert["triggerid"]},
+        )
+
+        self.worker.mongo.insert_one(
+            collection=self.worker.collection_alerts, document=alert
+        )
+
+        # now we try to crossmatch a point source with the alert
+        # for reference, the source is ZTF23aaebovb
+        contour = "contour90"
+        ra = 210.1037407
+        dec = 64.2197152
+
+        ra_geojson = float(ra)
+        ra_geojson -= 180.0
+        dec_geojson = float(dec)
+
+        object_position_query = dict()
+        object_position_query[f"localization.{contour}"] = {
+            "$geoIntersects": {
+                "$geometry": [ra_geojson, dec_geojson],
+            }
+        }
+        candidate_datetime = self.alert["dateobs"] + datetime.timedelta(days=1)
+
+        object_position_query["dateobs"] = {
+            "$gte": candidate_datetime - datetime.timedelta(days=7),
+            "$lte": candidate_datetime,
+        }
+
+        catalog_filter = {}
+        catalog_projection = {"_id": 0, "dateobs": 1}
+
+        s = self.worker.mongo.db[self.worker.collection_alerts].find(
+            {**object_position_query, **catalog_filter}, {**catalog_projection}
+        )
+        xmatches = list(s)
+        assert len(xmatches) == 1
+        assert xmatches[0]["dateobs"] == self.alert["dateobs"]
+
+        # this candidate should also match with contour50
+        del object_position_query[f"localization.{contour}"]
+        contour = "contour50"
+        object_position_query[f"localization.{contour}"] = {
+            "$geoIntersects": {
+                "$geometry": [ra_geojson, dec_geojson],
+            }
+        }
+
+        s = self.worker.mongo.db[self.worker.collection_alerts].find(
+            {**object_position_query, **catalog_filter}, {**catalog_projection}
+        )
+        xmatches = list(s)
+        assert len(xmatches) == 1
+        assert xmatches[0]["dateobs"] == self.alert["dateobs"]
+
+        # let's take a candidate with some random position outside of the contour to verify that it does not match.
+        # we take it at the exact opposite side of the sky
+        ra = 13.000929
+        dec = -2.4187257
+
+        ra_geojson = float(ra)
+        ra_geojson -= 180.0
+        dec_geojson = float(dec)
+
+        contour = "contour90"
+        object_position_query[f"localization.{contour}"] = {
+            "$geoIntersects": {
+                "$geometry": [ra_geojson, dec_geojson],
+            }
+        }
+
+        s = self.worker.mongo.db[self.worker.collection_alerts].find(
+            {**object_position_query, **catalog_filter}, {**catalog_projection}
+        )
+        xmatches = list(s)
+        assert len(xmatches) == 0

--- a/kowalski/tools/gcn_utils.py
+++ b/kowalski/tools/gcn_utils.py
@@ -1,0 +1,336 @@
+import os
+import traceback
+from urllib.parse import urlparse
+
+import astropy.units as u
+import gcn
+import healpy as hp
+import ligo.skymap.bayestar as ligo_bayestar
+import ligo.skymap.distance
+import ligo.skymap.io
+import ligo.skymap.moc
+import ligo.skymap.postprocess
+import numpy as np
+import requests
+import scipy
+from astropy.coordinates import ICRS, SkyCoord
+from astropy.table import Table
+from astropy.time import Time
+from astropy_healpix import HEALPix, nside_to_level, pixel_resolution_to_nside
+from shapely import get_parts, multipolygons
+from shapely.geometry import MultiLineString
+from shapely.ops import polygonize
+
+
+def get_trigger(root):
+    """Get the trigger ID from a GCN notice."""
+
+    property_name = "TrigID"
+    path = f".//Param[@name='{property_name}']"
+    elem = root.find(path)
+    if elem is None:
+        return None
+    value = elem.attrib.get("value", None)
+    if value is not None:
+        value = int(value)
+
+    return value
+
+
+def get_dateobs(root):
+    """Get the UTC event time from a GCN notice, rounded to the nearest second,
+    as a datetime.datetime object."""
+    dateobs = Time(
+        root.find(
+            "./WhereWhen/{*}ObsDataLocation"
+            "/{*}ObservationLocation"
+            "/{*}AstroCoords"
+            "[@coord_system_id='UTC-FK5-GEO']"
+            "/Time/TimeInstant/ISOTime"
+        ).text,
+        precision=0,
+    )
+
+    # FIXME: https://github.com/astropy/astropy/issues/7179
+    dateobs = Time(dateobs.iso)
+
+    return dateobs.datetime
+
+
+def get_skymap_url(root, notice_type):
+    url = None
+    available = False
+    # Try Fermi GBM convention
+    if notice_type == gcn.NoticeType.FERMI_GBM_FIN_POS:
+        url = root.find("./What/Param[@name='LocationMap_URL']").attrib["value"]
+        url = url.replace("http://", "https://")
+        url = url.replace("_locplot_", "_healpix_")
+        url = url.replace(".png", ".fit")
+
+    # Try Fermi GBM **subthreshold** convention. Stupid, stupid, stupid!!
+    if notice_type == gcn.NoticeType.FERMI_GBM_SUBTHRESH:
+        url = root.find("./What/Param[@name='HealPix_URL']").attrib["value"]
+
+    skymap = root.find("./What/Group[@type='GW_SKYMAP']")
+    if skymap is not None and url is None:
+        children = skymap.getchildren()
+        for child in children:
+            if child.attrib["name"] == "skymap_fits":
+                url = child.attrib["value"]
+                break
+
+    if url is not None:
+        # we have a URL, but is it available? We don't want to download the file here,
+        # so we'll just check the HTTP status code.
+        try:
+            response = requests.head(url, timeout=5)
+            if response.status_code == 200:
+                available = True
+        except requests.exceptions.RequestException:
+            pass
+
+    return url, available
+
+
+def is_retraction(root):
+    retraction = root.find("./What/Param[@name='Retraction']")
+    if retraction is not None:
+        retraction = int(retraction.attrib["value"])
+        if retraction == 1:
+            return True
+    return False
+
+
+def get_skymap_cone(root):
+    ra, dec, error = None, None, None
+    mission = urlparse(root.attrib["ivorn"]).path.lstrip("/")
+    # Try error cone
+    loc = root.find("./WhereWhen/ObsDataLocation/ObservationLocation")
+    if loc is None:
+        return ra, dec, error
+
+    ra = loc.find("./AstroCoords/Position2D/Value2/C1")
+    dec = loc.find("./AstroCoords/Position2D/Value2/C2")
+    error = loc.find("./AstroCoords/Position2D/Error2Radius")
+
+    if None in (ra, dec, error):
+        return ra, dec, error
+
+    ra, dec, error = float(ra.text), float(dec.text), float(error.text)
+
+    # Apparently, all experiments *except* AMON report a 1-sigma error radius.
+    # AMON reports a 90% radius, so for AMON, we have to convert.
+    if mission == "AMON":
+        error /= scipy.stats.chi(df=2).ppf(0.95)
+
+    return ra, dec, error
+
+
+def get_skymap_metadata(root, notice_type):
+    """Get the skymap for a GCN notice."""
+
+    skymap_url, available = get_skymap_url(root, notice_type)
+    if skymap_url is not None and available:
+        return "available", {"url": skymap_url, "name": skymap_url.split("/")[-1]}
+    elif skymap_url is not None and not available:
+        # can we get a cone?
+        ra, dec, error = get_skymap_cone(root)
+        if None not in (ra, dec, error):
+            return "cone", {
+                "ra": ra,
+                "dec": dec,
+                "error": error,
+                "name": f"{ra:.5f}_{dec:.5f}_{error:.5f}",
+            }
+        else:
+            return "unavailable", {"url": skymap_url, "name": skymap_url.split("/")[-1]}
+
+    if is_retraction(root):
+        return "retraction", None
+
+    ra, dec, error = get_skymap_cone(root)
+    if None not in (ra, dec, error):
+        return "cone", {
+            "ra": ra,
+            "dec": dec,
+            "error": error,
+            "name": f"{ra:.5f}_{dec:.5f}_{error:.5f}",
+        }
+
+    return "missing", None
+
+
+def from_cone(ra, dec, error, n_sigma=4):
+    localization_name = f"{ra:.5f}_{dec:.5f}_{error:.5f}"
+
+    center = SkyCoord(ra * u.deg, dec * u.deg)
+    radius = error * u.deg
+
+    # Determine resolution such that there are at least
+    # 16 pixels across the error radius.
+    hpx = HEALPix(
+        pixel_resolution_to_nside(radius / 16, round="up"), "nested", frame=ICRS()
+    )
+
+    # Find all pixels in the 4-sigma error circle.
+    ipix = hpx.cone_search_skycoord(center, n_sigma * radius)
+
+    # Convert to multi-resolution pixel indices and sort.
+    uniq = ligo.skymap.moc.nest2uniq(nside_to_level(hpx.nside), ipix.astype(np.int64))
+    i = np.argsort(uniq)
+    ipix = ipix[i]
+    uniq = uniq[i]
+
+    # Evaluate Gaussian.
+    distance = hpx.healpix_to_skycoord(ipix).separation(center)
+    probdensity = np.exp(
+        -0.5 * np.square(distance / radius).to_value(u.dimensionless_unscaled)
+    )
+    probdensity /= probdensity.sum() * hpx.pixel_area.to_value(u.steradian)
+
+    skymap = {
+        "localization_name": localization_name,
+        "uniq": uniq.tolist(),
+        "probdensity": probdensity.tolist(),
+    }
+
+    return skymap
+
+
+def from_url(url):
+    def get_col(m, name):
+        try:
+            col = m[name]
+        except KeyError:
+            return None
+        else:
+            return col.tolist()
+
+    filename = os.path.basename(urlparse(url).path)
+
+    skymap = ligo.skymap.io.read_sky_map(url, moc=True)
+
+    nside = 128
+    occulted = get_occulted(url, nside=nside)
+    if occulted is not None:
+        order = hp.nside2order(nside)
+        skymap_flat = ligo_bayestar.rasterize(skymap, order)["PROB"]
+        skymap_flat = hp.reorder(skymap_flat, "NESTED", "RING")
+        skymap_flat[occulted] = 0.0
+        skymap_flat = skymap_flat / skymap_flat.sum()
+        skymap_flat = hp.reorder(skymap_flat, "RING", "NESTED")
+        skymap = ligo_bayestar.derasterize(Table([skymap_flat], names=["PROB"]))
+
+    skymap = {
+        "localization_name": filename,
+        "uniq": get_col(skymap, "UNIQ"),
+        "probdensity": get_col(skymap, "PROBDENSITY"),
+        "distmu": get_col(skymap, "DISTMU"),
+        "distsigma": get_col(skymap, "DISTSIGMA"),
+        "distnorm": get_col(skymap, "DISTNORM"),
+    }
+
+    return skymap
+
+
+def get_occulted(url, nside=64):
+
+    m = Table.read(url, format="fits")
+    ra = m.meta.get("GEO_RA", None)
+    dec = m.meta.get("GEO_DEC", None)
+    error = m.meta.get("GEO_RAD", 67.5)
+
+    if (ra is None) or (dec is None) or (error is None):
+        return None
+
+    center = SkyCoord(ra * u.deg, dec * u.deg)
+    radius = error * u.deg
+
+    hpx = HEALPix(nside, "ring", frame=ICRS())
+
+    # Find all pixels in the circle.
+    ipix = hpx.cone_search_skycoord(center, radius)
+
+    return ipix
+
+
+@staticmethod
+def table_2d(skymap):
+    """Get multiresolution HEALPix dataset, probability density only."""
+    return Table(
+        [np.asarray(skymap["uniq"], dtype=np.int64), skymap["probdensity"]],
+        names=["UNIQ", "PROBDENSITY"],
+    )
+
+
+@staticmethod
+def flat_2d(skymap):
+    """Get flat resolution HEALPix dataset, probability density only."""
+    nside = 512
+    order = hp.nside2order(nside)
+    result = ligo_bayestar.rasterize(table_2d(skymap), order)["PROB"]
+    return hp.reorder(result, "NESTED", "RING")
+
+
+def get_contour(skymap):
+    # Calculate credible levels.
+    prob = flat_2d(skymap)
+    cls = 100 * ligo.skymap.postprocess.find_greedy_credible_levels(prob)
+
+    # Construct contours and return as a GeoJSON feature collection.
+    levels = [50, 90]
+    paths = ligo.skymap.postprocess.contour(cls, levels, degrees=True, simplify=True)
+    center = ligo.skymap.postprocess.posterior_max(prob)
+    contours = [
+        {
+            "type": "Point",
+            "coordinates": [center.ra.deg - 180, center.dec.deg],
+            "properties": {"credible_level": 0},
+        }
+    ] + [
+        {
+            "type": "MultiLineString",
+            "properties": {"credible_level": level},
+            # path is gonna be a list of lists of coordinates (lon, lat)
+            # we remove 180 from the longitude to make it work with mongo
+            # 'coordinates': [[[e[0]-180, e[1]] for e in line] for line in path]
+            "coordinates": path,
+        }
+        for level, path in zip(levels, paths)
+    ]
+
+    # for each geometries that is a MultiLineString, we need to convert to a Polygon instead
+    # for i, geometry in enumerate(contours):
+    #     if geometry["type"] != 'MultiLineString':
+    #         continue
+
+    # polygon = Polygon(geometry['coordinates'][0])
+    # for line in geometry['coordinates'][1:]:
+    #     polygon = polygon.difference(MultiLineString(line).buffer(0))
+    # #contour['geometries'][i]['coordinates'] = [[[e[0]-180, e[1]] for e in line] for line in polygon.exterior.coords]
+    # coords = list(polygon.exterior.coords)
+    # coords = [[e[0]-180, e[1]] for e in coords]
+    # contours[i]['coordinates'] = [coords]
+    # # save the coordinates to disk
+    # with open('polygon_coords.txt', 'w') as f:
+    #     f.write(str(contours[i]['coordinates']))
+    # contours[i]['type'] = 'Polygon'
+
+    for i, geometry in enumerate(contours):
+        if geometry["type"] != "MultiLineString":
+            continue
+        try:
+            multilinestring = MultiLineString(geometry["coordinates"])
+            polygons = multipolygons(get_parts(polygonize(multilinestring)))
+            contours[i]["coordinates"] = [
+                [[[e[0] - 180, e[1]] for e in line]]
+                for line in [
+                    list(polygon.exterior.coords) for polygon in polygons.geoms
+                ]
+            ]
+            contours[i]["type"] = "MultiPolygon"
+        except Exception as e:
+            print(e)
+            print(traceback.format_exc())
+
+    return contours

--- a/kowalski/tools/gcn_utils.py
+++ b/kowalski/tools/gcn_utils.py
@@ -274,7 +274,7 @@ def get_contour(skymap):
     cls = 100 * ligo.skymap.postprocess.find_greedy_credible_levels(prob)
 
     # Construct contours and return as a GeoJSON feature collection.
-    levels = [50, 90]
+    levels = [95]
     paths = ligo.skymap.postprocess.contour(cls, levels, degrees=True, simplify=True)
     center = ligo.skymap.postprocess.posterior_max(prob)
     contours = [
@@ -294,9 +294,5 @@ def get_contour(skymap):
         }
         for level, path in zip(levels, paths)
     ]
-
-    # save the 90 contour to file
-    with open("contour_coords.txt", "w") as f:
-        f.write(str(contours[1]["coordinates"]))
 
     return contours

--- a/kowalski/tools/tests.py
+++ b/kowalski/tools/tests.py
@@ -15,6 +15,12 @@ def test(use_docker=False):
 
     test_setups = [
         {
+            "part": "GCN alert broker components",
+            "container": "kowalski_ingester_1",
+            "test_script": "test_alert_broker_gcn.py",
+            "flaky": False,
+        },
+        {
             "part": "TURBO alert broker components",
             "container": "kowalski_ingester_1",
             "test_script": "test_alert_broker_turbo.py",


### PR DESCRIPTION
This PR adds a GCN broker, that ingests notices specified in the config.

Moreover, here we add the crossmatch with localizations from these events saved as contours represented by Polygons.

TODO:
- Shapely fails to generate from polygons from the MultiLine strings generated by ligo skymap. Maybe we can even query the multiline string and avoid the conversion to polygons entirely, but that is poorly documented online.
- Add a "watchdog" like in other ingesters. Here, as we do not need to find the topics because they are specified in the config the watchdog isn't really necessary. However, a watchdog that can re-subscribe us to a topic after an EOP is reached (end of partition, nothing left in that topic) could be nice. For now we just keep pooling even after an EOP, so its fine. But a watchdog could be a cleaner way to do it.
- Decide what to keep from every event. Right now we just keep dateobs, trigger_id, notice content and type, as well as the localization. Similarly to what we do in SkyPortal (where a lot of the skymap processing code used here comes from), we could extract properties from the notices and save them. By keeping them in the crossmatch results, users could have filters based not just on a candidate being in a localization (space and time, the max time after dateobs can be specified in the config too), but based on the localization properties.
